### PR TITLE
feat: make `/` and `/404` pages mobile responsive

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,6 +1,6 @@
 {
   "_variables": {
-    "lastUpdateCheck": 1724834265720
+    "lastUpdateCheck": 1725876809059
   },
   "devToolbar": {
     "enabled": false

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -61,7 +61,7 @@ export const Carousel = () => {
                 key={index}
               >
                 <img
-                  className="overflow-hidden rounded-2xl h-96 w-full md:w-40 lg:w-72"
+                  className="overflow-hidden rounded-2xl h-[30rem] lg:h-96 w-full md:w-40 lg:w-72"
                   src={`/idols/${index + 1}.webp`}
                   alt={`Picture of Idol ${index + 1}`}
                 />

--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -22,7 +22,7 @@ import { BsDiscord, BsReddit, BsGithub } from 'react-icons/bs';
         ><BsReddit className="fill-orange-600" />Reddit</a
       >&nbsp;|&nbsp;
       <a
-        href={Socials.Reddit}
+        href={Socials.GitHub}
         target="_blank"
         rel="noreferrer"
         class="font-semibold flex flex-row items-center justify-center gap-x-1"

--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -1,27 +1,33 @@
 ---
 import { Socials } from '@/constants';
-import { BsDiscord, BsReddit } from 'react-icons/bs';
+import { BsDiscord, BsReddit, BsGithub } from 'react-icons/bs';
 ---
 
 <footer class="p-2 lg:p-4">
   <!-- Mobile Screen Footer -->
   <span class="flex lg:hidden flex-col justify-center items-center text-sm">
     <span class="flex text-right text-sm">
-      <span class="font-bold">Find us on:</span>
-
-      &nbsp;<a
+      <a
         href={Socials.Discord}
         target="_blank"
         rel="noreferrer"
-        class="font-semibold !text-blue-600">Discord</a
-      >,&nbsp;
+        class="font-semibold !text-blue-700 flex flex-row items-center justify-center gap-x-1"
+        ><BsDiscord className="fill-blue-600" />Discord</a
+      >&nbsp;|&nbsp;
       <a
         href={Socials.Reddit}
         target="_blank"
         rel="noreferrer"
-        class="font-semibold !text-orange-600">Reddit</a
-      >&nbsp;&&nbsp;
-      <a href={Socials.Reddit} target="_blank" rel="noreferrer" class="font-semibold">GitHub</a>
+        class="font-semibold !text-orange-700 flex flex-row items-center justify-center gap-x-1"
+        ><BsReddit className="fill-orange-600" />Reddit</a
+      >&nbsp;|&nbsp;
+      <a
+        href={Socials.Reddit}
+        target="_blank"
+        rel="noreferrer"
+        class="font-semibold flex flex-row items-center justify-center gap-x-1"
+        ><BsGithub />GitHub</a
+      >
     </span>
 
     <div>

--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -3,9 +3,9 @@ import { Socials } from '@/constants';
 import { BsDiscord, BsReddit, BsGithub } from 'react-icons/bs';
 ---
 
-<footer class="p-2 lg:p-4">
+<footer class="p-2 lg:p-4 pt-3 lg:pt-4">
   <!-- Mobile Screen Footer -->
-  <span class="flex lg:hidden flex-col justify-center items-center text-sm">
+  <span class="flex lg:hidden flex-col justify-center items-center text-sm gap-y-1">
     <span class="flex text-right text-sm">
       <a
         href={Socials.Discord}

--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -3,33 +3,64 @@ import { Socials } from '@/constants';
 import { BsDiscord, BsReddit } from 'react-icons/bs';
 ---
 
-<footer class="flex justify-between p-4">
-  <span class="text-left pl-16">
-    Made with ❤️ by
-    <a target="_blank" rel="noreferrer" href={Socials.GitHub} class="font-semibold">
-      Pujo Atlas Kolkata
-    </a>
+<footer class="p-2 lg:p-4">
+  <!-- Mobile Screen Footer -->
+  <span class="flex lg:hidden flex-col justify-center items-center text-sm">
+    <span class="flex text-right text-sm">
+      <span class="font-bold">Find us on:</span>
+
+      &nbsp;<a
+        href={Socials.Discord}
+        target="_blank"
+        rel="noreferrer"
+        class="font-semibold !text-blue-600">Discord</a
+      >,&nbsp;
+      <a
+        href={Socials.Reddit}
+        target="_blank"
+        rel="noreferrer"
+        class="font-semibold !text-orange-600">Reddit</a
+      >&nbsp;&&nbsp;
+      <a href={Socials.Reddit} target="_blank" rel="noreferrer" class="font-semibold">GitHub</a>
+    </span>
+
+    <div>
+      Made with ❤️ by
+      <a target="_blank" rel="noreferrer" href={Socials.GitHub} class="font-semibold">
+        Pujo Atlas Kolkata
+      </a>
+    </div>
   </span>
-  <span class="text-right flex flex-row gap-x-2">
-    <span class="font-bold">Find us on:</span>
-    <a
-      href={Socials.Discord}
-      target="_blank"
-      rel="noreferrer"
-      class="hover:underline hover:underline-offset-1 hover:decoration-2 hover:decoration-blue-600 flex flex-row items-center gap-x-2"
-    >
-      <BsDiscord className="size-6 fill-blue-600" />
-      Discord
-    </a>
-    &nbsp;|&nbsp;
-    <a
-      href={Socials.Reddit}
-      target="_blank"
-      rel="noreferrer"
-      class="hover:underline hover:underline-offset-1 hover:decoration-2 hover:decoration-orange-600 flex flex-row gap-x-2"
-    >
-      <BsReddit className="size-6 fill-orange-600" />
-      Reddit
-    </a>
+
+  <!-- Large Screen Footer -->
+  <span class="hidden lg:flex justify-between">
+    <span class="text-left pl-16">
+      Made with ❤️ by
+      <a target="_blank" rel="noreferrer" href={Socials.GitHub} class="font-semibold">
+        Pujo Atlas Kolkata
+      </a>
+    </span>
+    <span class="text-right flex flex-row gap-x-2">
+      <span class="font-bold">Find us on:</span>
+      <a
+        href={Socials.Discord}
+        target="_blank"
+        rel="noreferrer"
+        class="hover:underline hover:underline-offset-1 hover:decoration-2 hover:decoration-blue-600 flex flex-row items-center gap-x-2"
+      >
+        <BsDiscord className="size-6 fill-blue-600" />
+        Discord
+      </a>
+      &nbsp;|&nbsp;
+      <a
+        href={Socials.Reddit}
+        target="_blank"
+        rel="noreferrer"
+        class="hover:underline hover:underline-offset-1 hover:decoration-2 hover:decoration-orange-600 flex flex-row gap-x-2"
+      >
+        <BsReddit className="size-6 fill-orange-600" />
+        Reddit
+      </a>
+    </span>
   </span>
 </footer>

--- a/src/components/shared/Header.astro
+++ b/src/components/shared/Header.astro
@@ -1,19 +1,19 @@
 ---
 import { Image } from 'astro:assets';
 import Icon from '~/public/icon.png';
-import { MobileHamburgerNavbar } from './Navbar';
+import { MobileHeaderLangSwitcher } from './Navbar';
 
 const currentPath = Astro.url.pathname;
 ---
 
 <header class="w-full p-3 lg:p-4">
-  <span class="absolute lg:hidden text-left z-50 left-4 -top-2">
-    <MobileHamburgerNavbar path={currentPath} />
-  </span>
-  <nav class="flex justify-center items-center lg:justify-start lg:items-start">
-    <a class="font-semibold font-work flex items-center gap-2 text-xs lg:text-base" href="/">
-      <Image src={Icon} alt="Logo" class="w-4 lg:w-6 h-4 lg:h-6 rounded-md overflow-hidden" />
+  <nav class="flex flex-row justify-between">
+    <a class="font-semibold font-work flex items-center gap-2" href="/">
+      <Image src={Icon} alt="Logo" class="w-5 lg:w-6 h-5 lg:h-6 rounded-md overflow-hidden" />
       Pujo Atlas
     </a>
+    <div class="flex lg:hidden">
+      <MobileHeaderLangSwitcher path={currentPath} />
+    </div>
   </nav>
 </header>

--- a/src/components/shared/Header.astro
+++ b/src/components/shared/Header.astro
@@ -3,10 +3,10 @@ import { Image } from 'astro:assets';
 import Icon from '~/public/icon.png';
 ---
 
-<header class="flex w-full p-4">
+<header class="flex justify-center items-center lg:justify-start lg:items-start w-full p-3 lg:p-4">
   <nav>
-    <a class="font-semibold font-work flex items-center gap-2" href="/">
-      <Image src={Icon} alt="Logo" class="w-6 h-6 rounded-md overflow-hidden" />
+    <a class="font-semibold font-work flex items-center gap-2 text-xs lg:text-base" href="/">
+      <Image src={Icon} alt="Logo" class="w-4 lg:w-6 h-4 lg:h-6 rounded-md overflow-hidden" />
       Pujo Atlas
     </a>
   </nav>

--- a/src/components/shared/Header.astro
+++ b/src/components/shared/Header.astro
@@ -1,10 +1,16 @@
 ---
 import { Image } from 'astro:assets';
 import Icon from '~/public/icon.png';
+import { MobileHamburgerNavbar } from './Navbar';
+
+const currentPath = Astro.url.pathname;
 ---
 
-<header class="flex justify-center items-center lg:justify-start lg:items-start w-full p-3 lg:p-4">
-  <nav>
+<header class="w-full p-3 lg:p-4">
+  <span class="absolute lg:hidden text-left z-50 left-4 -top-2">
+    <MobileHamburgerNavbar path={currentPath} />
+  </span>
+  <nav class="flex justify-center items-center lg:justify-start lg:items-start">
     <a class="font-semibold font-work flex items-center gap-2 text-xs lg:text-base" href="/">
       <Image src={Icon} alt="Logo" class="w-4 lg:w-6 h-4 lg:h-6 rounded-md overflow-hidden" />
       Pujo Atlas

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -2,6 +2,7 @@ import { getRelativeLocaleUrl } from 'astro:i18n';
 import { BsGithub } from 'react-icons/bs';
 import { GoHomeFill } from 'react-icons/go';
 import { MdTranslate } from 'react-icons/md';
+import { GiHamburgerMenu } from 'react-icons/gi';
 import {
   cn,
   getAlternateLanguage,
@@ -77,6 +78,10 @@ export const MobileHamburgerNavbar = ({ path }: Props) => {
 
   return (
     <>
+      <button className="outline-none mobile-menu-button mt-5">
+        <GiHamburgerMenu className="h-5 w-5" />
+      </button>
+
       <div className="hidden">
         {navItems.map((item, index) => (
           <a

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -46,7 +46,7 @@ function generateNavItems(path: string, currentLang: 'en' | 'bn'): Array<NavItem
   ];
 }
 
-export const Navbar = ({ path }: Props) => {
+export const LargeNavbar = ({ path }: Props) => {
   const currentLang = getCurrentLanguage(path);
   const navItems = generateNavItems(path, currentLang);
 
@@ -71,4 +71,29 @@ export const Navbar = ({ path }: Props) => {
   );
 };
 
-export default Navbar;
+export const MobileHamburgerNavbar = ({ path }: Props) => {
+  const currentLang = getCurrentLanguage(path);
+  const navItems = generateNavItems(path, currentLang);
+
+  return (
+    <>
+      <div className="hidden">
+        {navItems.map((item, index) => (
+          <a
+            key={index}
+            href={item.href}
+            data-active={(item.href === path || item.href === '/bn') && index === 0} // hotfix for netlify hidden trailing slash issue
+            className={cn(
+              'outline outline-primary-foreground outline-1 bg-primary-background',
+              'data-[active=true]:outline-2 data-[active=true]:bg-[#fed7aa]',
+              'p-2 grid place-items-center rounded-lg w-16',
+            )}
+          >
+            {item.icon}
+            <span className="font-work text-xs font-semibold">{item.label}</span>
+          </a>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -2,7 +2,6 @@ import { getRelativeLocaleUrl } from 'astro:i18n';
 import { BsGithub } from 'react-icons/bs';
 import { GoHomeFill } from 'react-icons/go';
 import { MdTranslate } from 'react-icons/md';
-import { GiHamburgerMenu } from 'react-icons/gi';
 import {
   cn,
   getAlternateLanguage,
@@ -42,7 +41,7 @@ function generateNavItems(path: string, currentLang: 'en' | 'bn'): Array<NavItem
     {
       label: oppositeLang === 'en' ? 'English' : 'বাংলা',
       href: getAlternateLanguagePath(path),
-      icon: <MdTranslate className="size-6 fill-primary-foreground" />,
+      icon: <MdTranslate className="size-4 lg:size-6 fill-primary-foreground" />,
     },
   ];
 }
@@ -72,33 +71,19 @@ export const LargeNavbar = ({ path }: Props) => {
   );
 };
 
-export const MobileHamburgerNavbar = ({ path }: Props) => {
+export const MobileHeaderLangSwitcher = ({ path }: Props) => {
   const currentLang = getCurrentLanguage(path);
   const navItems = generateNavItems(path, currentLang);
 
   return (
-    <>
-      <button className="outline-none mobile-menu-button mt-5">
-        <GiHamburgerMenu className="h-5 w-5" />
-      </button>
-
-      <div className="hidden">
-        {navItems.map((item, index) => (
-          <a
-            key={index}
-            href={item.href}
-            data-active={(item.href === path || item.href === '/bn') && index === 0} // hotfix for netlify hidden trailing slash issue
-            className={cn(
-              'outline outline-primary-foreground outline-1 bg-primary-background',
-              'data-[active=true]:outline-2 data-[active=true]:bg-[#fed7aa]',
-              'p-2 grid place-items-center rounded-lg w-16',
-            )}
-          >
-            {item.icon}
-            <span className="font-work text-xs font-semibold">{item.label}</span>
-          </a>
-        ))}
-      </div>
-    </>
+    <a
+      href={navItems[2].href}
+      className={cn(
+        'outline outline-primary-foreground outline-1 bg-primary-background',
+        'flex items-center justify-center rounded-md p-2 w-8 h-8',
+      )}
+    >
+      {navItems[2].icon}
+    </a>
   );
 };

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -82,6 +82,7 @@ export const MobileHeaderLangSwitcher = ({ path }: Props) => {
         'outline outline-primary-foreground outline-1 bg-primary-background',
         'flex items-center justify-center rounded-md p-2 w-8 h-8',
       )}
+      aria-label={navItems[2].label}
     >
       {navItems[2].icon}
     </a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -61,7 +61,7 @@ const {
     class={cn(
       'bg-secondary-background',
       'text-primary-foreground [&_*]:text-primary-foreground',
-      'min-w-screen min-h-screen flex flex-col overflow-hidden',
+      'min-w-screen min-h-screen flex flex-col overflow-x-hidden',
       '[&_*::-webkit-scrollbar]:w-2 [&_*::-webkit-scrollbar-track]:bg-primary-foreground',
       '[&_*::-webkit-scrollbar-thumb]:bg-secondary-background',
     )}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,9 +10,9 @@ import alkatraWoff2 from '@fontsource-variable/alkatra/files/alkatra-latin-wght-
 
 import Header from '@/components/shared/Header.astro';
 import Footer from '@/components/shared/Footer.astro';
-import Navbar from '@/components/shared/Navbar';
 import { cn } from '@/libs/utils';
 import { ViewTransitions } from 'astro:transitions';
+import { LargeNavbar, MobileHamburgerNavbar } from '@/components/shared/Navbar';
 
 const currentPath = Astro.url.pathname;
 
@@ -69,8 +69,9 @@ const {
     <Header />
     <div class="flex flex-1">
       <aside class="hidden lg:grid place-items-center">
-        <Navbar path={currentPath} />
+        <LargeNavbar path={currentPath} />
       </aside>
+      <MobileHamburgerNavbar path={currentPath} />
       <slot />
     </div>
     <Footer />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -62,8 +62,9 @@ const {
       'bg-secondary-background',
       'text-primary-foreground [&_*]:text-primary-foreground',
       'min-w-screen min-h-screen flex flex-col overflow-x-hidden',
-      '[&_*::-webkit-scrollbar]:w-2 [&_*::-webkit-scrollbar-track]:bg-primary-foreground',
-      '[&_*::-webkit-scrollbar-thumb]:bg-secondary-background',
+      '[&_*::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:w-2',
+      '[&_*::-webkit-scrollbar-track]:bg-primary-foreground [&::-webkit-scrollbar-track]:bg-primary-foreground',
+      '[&_*::-webkit-scrollbar-thumb]:bg-secondary-background [&::-webkit-scrollbar-thumb]:bg-secondary-background',
     )}
   >
     <Header />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ import Header from '@/components/shared/Header.astro';
 import Footer from '@/components/shared/Footer.astro';
 import { cn } from '@/libs/utils';
 import { ViewTransitions } from 'astro:transitions';
-import { LargeNavbar, MobileHamburgerNavbar } from '@/components/shared/Navbar';
+import { LargeNavbar } from '@/components/shared/Navbar';
 
 const currentPath = Astro.url.pathname;
 
@@ -71,7 +71,6 @@ const {
       <aside class="hidden lg:grid place-items-center">
         <LargeNavbar path={currentPath} />
       </aside>
-      <MobileHamburgerNavbar path={currentPath} />
       <slot />
     </div>
     <Footer />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,7 +68,7 @@ const {
   >
     <Header />
     <div class="flex flex-1">
-      <aside class="grid place-items-center">
+      <aside class="hidden lg:grid place-items-center">
         <Navbar path={currentPath} />
       </aside>
       <slot />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,14 +6,17 @@ import { cn } from '@/libs/utils';
 <Layout title="404 | Page Not Found">
   <main
     class={cn(
-      'flex-1 flex flex-col items-center justify-center gap-4',
-      'bg-primary-background p-16',
+      'flex-1 flex flex-col items-center justify-center gap-2 lg:gap-4',
+      'bg-primary-background p-2 lg:p-16',
       'rounded-l-xl shadow-l-xl',
     )}
   >
-    <h1 class="text-9xl font-bold">404.</h1>
-    <p class="font-work">Uh oh! Looks like you lost your way.</p>
-    <a class={cn('italic flex py-1 px-20', 'rounded-full outline outline-1')} href="/">
+    <h1 class="text-8xl lg:text-9xl font-bold text-center">404!</h1>
+    <p class="font-work text-center">Uh oh! Looks like you lost your way.</p>
+    <a
+      class={cn('italic flex py-1 lg:px-20 px-6 text-center', 'rounded-full outline outline-1')}
+      href="/"
+    >
       Go back to homepage -&gt;
     </a>
   </main>

--- a/src/pages/bn/index.astro
+++ b/src/pages/bn/index.astro
@@ -35,7 +35,7 @@ import { cn } from '@/libs/utils';
         <span class="font-noto font-bold"> শীঘ্রই আসছে </span>
       </div>
     </span>
-    <div class="h-[400px]">
+    <div class="h-[500px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/bn/index.astro
+++ b/src/pages/bn/index.astro
@@ -8,22 +8,34 @@ import { cn } from '@/libs/utils';
 <Layout>
   <main
     class={cn(
-      'flex-1 flex flex-col gap-6',
-      'bg-primary-background py-12 px-20',
-      'rounded-l-xl shadow-l-xl max-h-[85vh] overflow-y-auto',
+      'flex-1 flex flex-col gap-3 gap-y-3 lg:gap-y-0 lg:gap-6',
+      'bg-primary-background p-3 lg:p-4 lg:py-12 lg:px-20',
+      'rounded-l-xl shadow-l-xl overflow-y-auto',
     )}
   >
-    <h1 class="font-alkatra font-semibold text-6xl">পুজো অ্যাটলাস</h1>
-    <p class="font-alkatra">সবচেয়ে উন্নত প্যান্ডেল হপিং অ্যাপ*</p>
-    <div
-      class={cn('text-xs py-1 px-4 outline outline-1', 'rounded-xl w-fit flex items-center gap-2')}
-    >
-      <PlaystoreIcon />
-      <span class="font-bold"> Google Play </span>
-      <span>|</span>
-      <span class="font-noto font-semibold"> শীঘ্রই আসছে </span>
-    </div>
-    <div class="w-full">
+    <h1 class="font-alkatra font-semibold text-[55px] lg:text-6xl pt-0 text-center lg:text-left">
+      পুজো অ্যাটলাস
+    </h1>
+    <p class="block lg:hidden font-alkatra text-center leading-5">
+      সবচেয়ে উন্নত <br /> প্যান্ডেল হপিং অ্যাপ*
+    </p>
+    <p class="hidden lg:block font-alkatra text-left leading-normal">
+      সবচেয়ে উন্নত প্যান্ডেল হপিং অ্যাপ*
+    </p>
+    <span class="flex justify-center items-center lg:block">
+      <div
+        class={cn(
+          'text-xs py-1 px-4 outline outline-1',
+          'rounded-xl w-fit flex items-center gap-2',
+        )}
+      >
+        <PlaystoreIcon />
+        <span class="font-bold"> Google Play </span>
+        <span>|</span>
+        <span class="font-noto font-bold"> শীঘ্রই আসছে </span>
+      </div>
+    </span>
+    <div class="h-[400px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,22 +8,34 @@ import { cn } from '@/libs/utils';
 <Layout>
   <main
     class={cn(
-      'flex-1 flex flex-col gap-6',
-      'bg-primary-background p-4 lg:py-12 lg:px-20',
+      'flex-1 flex flex-col gap-3 gap-y-3 lg:gap-y-0 lg:gap-6',
+      'bg-primary-background p-3 lg:p-4 lg:py-12 lg:px-20',
       'rounded-l-xl shadow-l-xl overflow-y-auto',
     )}
   >
-    <h1 class="font-work font-semibold text-6xl">Pujo Atlas</h1>
-    <p class="font-work">The most advanced pandal hopping experience*</p>
-    <div
-      class={cn('text-xs py-1 px-4 outline outline-1', 'rounded-xl w-fit flex items-center gap-2')}
-    >
-      <PlaystoreIcon />
-      <span class="font-semibold"> Google Play </span>
-      <span>|</span>
-      <span> Coming Soon </span>
-    </div>
-    <div class="w-full">
+    <h1 class="font-work font-semibold text-[55px] lg:text-6xl pt-0 text-center lg:text-left">
+      Pujo Atlas
+    </h1>
+    <p class="block lg:hidden font-work text-center leading-5">
+      The most advanced <br /> pandal hopping experience*
+    </p>
+    <p class="hidden lg:block font-work text-left leading-normal">
+      The most advanced pandal hopping experience*
+    </p>
+    <span class="flex justify-center items-center lg:block">
+      <div
+        class={cn(
+          'text-xs py-1 px-4 outline outline-1',
+          'rounded-xl w-fit flex items-center gap-2',
+        )}
+      >
+        <PlaystoreIcon />
+        <span class="font-semibold"> Google Play </span>
+        <span>|</span>
+        <span> Coming Soon </span>
+      </div>
+    </span>
+    <div class="h-[384px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import { cn } from '@/libs/utils';
         <span> Coming Soon </span>
       </div>
     </span>
-    <div class="h-auto lg:h-[400px]">
+    <div class="h-[400px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import { cn } from '@/libs/utils';
         <span> Coming Soon </span>
       </div>
     </span>
-    <div class="h-[400px]">
+    <div class="h-auto lg:h-[400px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import { cn } from '@/libs/utils';
     class={cn(
       'flex-1 flex flex-col gap-6',
       'bg-primary-background p-4 lg:py-12 lg:px-20',
-      'rounded-l-xl shadow-l-xl max-h-[85vh] overflow-y-auto',
+      'rounded-l-xl shadow-l-xl overflow-y-auto',
     )}
   >
     <h1 class="font-work font-semibold text-6xl">Pujo Atlas</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import { cn } from '@/libs/utils';
         <span> Coming Soon </span>
       </div>
     </span>
-    <div class="h-[384px]">
+    <div class="h-auto lg:h-[400px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import { cn } from '@/libs/utils';
         <span> Coming Soon </span>
       </div>
     </span>
-    <div class="h-[400px]">
+    <div class="h-[500px]">
       <Carousel client:load client:only="react" />
     </div>
   </main>


### PR DESCRIPTION
Closes #29, #28

## Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/blob/dev/CONTRIBUTING.md)
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

made the `/` and `/404` pages mobile responsive

---

## Screenshots

![deploy-preview-57--pujoatlas netlify app_(iPhone SE)](https://github.com/user-attachments/assets/53c4c6de-8f9c-4091-9d02-3dd79bfd6f0b)

![deploy-preview-57--pujoatlas netlify app_404(iPhone SE) (1)](https://github.com/user-attachments/assets/a92429d4-b625-47ca-8705-f13f34870367)

![deploy-preview-57--pujoatlas netlify app_404(iPhone SE)](https://github.com/user-attachments/assets/c03e9b0c-baa7-4672-9079-6c3c34487f45)