### PR TITLE
fix: configured github link to open in new tab

### DIFF
--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -56,6 +56,8 @@ export const LargeNavbar = ({ path }: Props) => {
         <a
           key={index}
           href={item.href}
+          target={item.href === Socials.GitHub ? '_blank' : '_self'}
+          rel={item.href === Socials.GitHub ? 'noopener noreferrer' : ''}
           data-active={(item.href === path || item.href === '/bn') && index === 0} // hotfix for netlify hidden trailing slash issue
           className={cn(
             'outline outline-primary-foreground outline-1 bg-primary-background',


### PR DESCRIPTION
Closes #54 

## Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/blob/dev/CONTRIBUTING.md)
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Clicking on github link in navbar opens new tab
---

## Screenshots

![image](https://github.com/user-attachments/assets/25de0123-c6b3-4944-8318-7ae5c0309b63)

