### PR TITLE
feat: add Alert Dialog on non-prod URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -699,6 +702,19 @@ packages:
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/react-alert-dialog@1.1.14':
+    resolution: {integrity: sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -4014,6 +4030,20 @@ snapshots:
       - supports-color
 
   '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/styles/globals.css";
 
 import { type Metadata } from "next";
 import { gilroy, geist } from "@/styles/fonts";
-import { AnimatedGridPattern, Footer, Navbar } from "@/components";
+import { AnimatedGridPattern, Footer, Navbar, BetaAlert } from "@/components";
 import { Toaster } from "sonner";
 import { PostHogProvider } from "@/providers";
 import { Constants } from "@/lib";
@@ -39,6 +39,7 @@ export default function RootLayout({
           <PostHogProvider>
             <AnimatedGridPattern className="pointer-events-none fixed inset-0 -z-10 h-full w-full" />
             <Navbar />
+            {process.env.ENVIRONMENT !== "production" && <BetaAlert />}
             {children}
             <Footer />
             <Toaster

--- a/src/components/Alert/betaalert.component.tsx
+++ b/src/components/Alert/betaalert.component.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import Link from "next/link";
+
+export const BetaAlert = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const acceptedBeta = localStorage.getItem("acceptedBeta");
+    if (!acceptedBeta) {
+      setOpen(true);
+    }
+  }, []);
+
+  // Function to handle the close action
+  const handleContinue = () => {
+    setOpen(false);
+    localStorage.setItem("acceptedBeta", "true");
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Welcome to Pujo Atlas BETA</AlertDialogTitle>
+          <AlertDialogDescription>
+            Pujo Atlas BETA may occasionally be unstable. Are you sure you want
+            to continue?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Link href={"https://atlas.ourkolkata.in"} rel="noopener noreferrer">
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+          </Link>
+          <AlertDialogAction onClick={() => handleContinue()}>
+            Continue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/Alert/betaalert.component.tsx
+++ b/src/components/Alert/betaalert.component.tsx
@@ -11,9 +11,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import Link from "next/link";
+import { Constants } from "@/lib";
+import { useRouter } from "next/navigation";
 
 export const BetaAlert = () => {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -25,7 +27,6 @@ export const BetaAlert = () => {
 
   // Function to handle the close action
   const handleContinue = () => {
-    setOpen(false);
     localStorage.setItem("acceptedBeta", "true");
   };
 
@@ -33,16 +34,22 @@ export const BetaAlert = () => {
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Welcome to Pujo Atlas BETA</AlertDialogTitle>
-          <AlertDialogDescription>
+          <AlertDialogTitle className="text-left">
+            Welcome to Pujo Atlas BETA
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-left">
             Pujo Atlas BETA may occasionally be unstable. Are you sure you want
             to continue?
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <Link href={"https://atlas.ourkolkata.in"} rel="noopener noreferrer">
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-          </Link>
+          <AlertDialogCancel
+            onClick={() => {
+              router.push(Constants.urls.prod);
+            }}
+          >
+            Nope
+          </AlertDialogCancel>
           <AlertDialogAction onClick={() => handleContinue()}>
             Continue
           </AlertDialogAction>

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -1,0 +1,1 @@
+export * from "@/components/Alert/betaalert.component";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "@/components/stars";
 export * from "@/components/Navbar/navbar.component";
 export * from "@/components/Footer/footer.component";
 export * from "@/components/Cards";
+export * from "@/components/Alert";

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import * as React from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "bg-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-base border-border shadow-shadow fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border-2 p-6 duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-3 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("font-heading text-lg", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("font-base text-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "neutral" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export * from "@/components/ui/marquee";
 export * from "@/components/ui/sheet";
 export * from "@/components/ui/sonner";
 export * from "@/components/ui/tooltip";
+export * from "@/components/ui/alert-dialog";

--- a/src/lib/contants.ts
+++ b/src/lib/contants.ts
@@ -317,6 +317,20 @@ export const team: Record<string, MemberDetails[]> = {
       },
       department: "Web",
     },
+    {
+      id: "yaroteburu",
+      name: "Yaroteburu",
+      avatar:
+        "https://api.dicebear.com/9.x/lorelei/svg?seed=liam&eyes=variant02&frecklesProbability=0&glassesProbability=100&hair=variant07&eyebrows=variant07&glasses=variant04&nose=variant04",
+      socials: {
+        discord: "https://discord.com/users/422747998657839116",
+        linkedin:
+          "https://www.linkedin.com/in/soumyadeep-bhattacharya-65b74b170/",
+        github: "https://github.com/SBhattacharya45",
+        website: "https://www.soumyadeep.info/",
+      },
+      department: "Web",
+    },
   ],
   "Backend Team": [
     {


### PR DESCRIPTION
Closes #<issue>

## Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/blob/dev/CONTRIBUTING.md)
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

An alert dialog should show up automatically when any user is visiting any non-prod URL, prompting them to continue or cancel.
---

## Screenshots
![image](https://github.com/user-attachments/assets/6017129f-1bad-4b29-9e91-90cc3630cce0)
