### PR TITLE
fix(client): made discord optional

### DIFF
--- a/src/lib/contants.ts
+++ b/src/lib/contants.ts
@@ -87,7 +87,7 @@ type MemberDetails = {
   | {
       department: (typeof Tech)[number];
       socials: {
-        discord: string;
+        discord?: string;
         github: string;
         linkedin?: string;
         twitter?: string;
@@ -97,7 +97,7 @@ type MemberDetails = {
   | {
       department: (typeof NonTech)[number];
       socials: {
-        discord: string;
+        discord?: string;
         github?: string;
         linkedin?: string;
         twitter?: string;
@@ -204,8 +204,8 @@ export const team: Record<string, MemberDetails[]> = {
       department: "Community",
     },
     {
-      id: "rishi",
-      name: "rishi",
+      id: "kochurighugni",
+      name: "kochurighugni",
       avatar: "https://api.dicebear.com/9.x/lorelei/svg?seed=rishi",
       socials: {
         discord: "https://discord.com/users/283499137977024513",
@@ -248,12 +248,11 @@ export const team: Record<string, MemberDetails[]> = {
       department: "Web",
     },
     {
-      id: "yaroteburu",
-      name: "Yaroteburu",
+      id: "soumyadeep",
+      name: "Soumyadeep",
       avatar:
         "https://api.dicebear.com/9.x/lorelei/svg?seed=liam&eyes=variant02&frecklesProbability=0&glassesProbability=100&hair=variant07&eyebrows=variant07&glasses=variant04&nose=variant04",
       socials: {
-        discord: "https://discord.com/users/422747998657839116",
         linkedin: "https://www.linkedin.com/in/soumyadeep-bhattacharya-65b74b170/",
         github: "https://github.com/SBhattacharya45",
         website: "https://www.soumyadeep.info/",


### PR DESCRIPTION
Closes #<issue>

## Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/blob/dev/CONTRIBUTING.md)
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Discord is now an optional field in socials


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated team member names and profiles for improved accuracy.
  * Adjusted social links to make Discord information optional for team members.

* **Bug Fixes**
  * Removed outdated Discord link from a team member’s profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->