### PR TITLE
chore: disallow cdn/cgi in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /cdn-cgi/
 
 Sitemap: https://atlas.ourkolkata.in/sitemap-index.xml


### PR DESCRIPTION
Closes https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/issues/266

## Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/Pujo-Atlas-Kolkata/PujoAtlasKol-Web/blob/dev/CONTRIBUTING.md)
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updated robots.txt file to include `Disallow: /cdn-cgi/`.
Ref: https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/#disallow-using-robotstxt
---

## Screenshots

Added `Disallow: /cdn-cgi/` in robots.txt
<img width="1470" alt="Screenshot 2025-07-06 at 4 17 10 PM" src="https://github.com/user-attachments/assets/63a97e04-bf5e-4374-8e6e-003c9c553316" />

